### PR TITLE
don't have uglyfy.js convert utf-8 character

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -58,7 +58,8 @@ function includeEntries(ops, next) {
 				//ast = pro.ast_mangle(ast);
 				//ast = pro.ast_squeeze(ast);
 				this(null, pro.gen_code(ast, {
-					beautify: true
+					beautify: true,
+					ascii_only: true
 				}));
 			} catch(e) {
 				this(null, content);


### PR DESCRIPTION
by default uglify.js converts utf-8 chars. The option ascii_only leaves them alone. 

this make nexe happy because otherwise the nodejs compile would fail with non-ascii character error.
