### PR TITLE
have sardines catch empty navigator & document objects

### DIFF
--- a/lib/tpl/head.ejs
+++ b/lib/tpl/head.ejs
@@ -35,3 +35,27 @@ if(typeof window == 'undefined') {
 if(typeof window.process == "undefined") {
   window.process = { };
 }
+
+if(typeof document == 'undefined') {
+  global.document = global;
+}
+
+if(typeof document.documentElement == 'undefined') {
+  document.documentElement = {};
+}
+
+if(typeof document.documentElement.style == 'undefined') {
+  document.documentElement.style = {};
+}
+
+if(typeof navigator == 'undefined') {
+  global.navigator = global;
+}
+
+if(typeof navigator.userAgent == 'undefined') {
+  navigator.userAgent = "sardines";
+}
+
+if(typeof navigator.platform == 'undefined') {
+  navigator.platform = "sardines";
+}


### PR DESCRIPTION
basically to get socket-io.client to pass with nexe
